### PR TITLE
[Apollo GraphQL] Day 4: Subscriptions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+    "presets": [
+        "@babel/preset-env",
+    ],
+    "plugins": [
+        [
+          "@babel/plugin-proposal-class-properties"
+        ]
+    ]
+  }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
     "presets": [
-        "@babel/preset-env",
+        "@babel/preset-env"
     ],
     "plugins": [
         [

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=9000
+NODE_ENV=dev

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,36 @@
+
+{
+    "env": {
+        "es6": true,
+        "browser": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react"
+    ],
+    
+    "rules": {
+        "no-empty": 0,
+        "no-irregular-whitespace": 0,
+        "import/prefer-default-export": "off",
+        "indent": "off",
+        "react/jsx-indent": [
+            "error",
+            2
+        ],
+        "no-unused-vars": "off"
+  
+    }
+  }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+node_modules
+.env

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,7 @@
+{
+    "verbose": true,
+    "watch": ["src/**/*.js", "src/**/*.graphql"],
+    "runOnChangeOnly": false,
+    "ext": "js json graphql"
+  }
+  

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "apollo-server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "apollo-server-express": "^2.19.1",
+    "dotenv": "^8.2.0",
+    "esm": "^3.2.25",
+    "express": "^4.17.1",
+    "graphql": "^15.4.0",
+    "merge-graphql-schemas": "^1.7.8",
+    "requirejs": "^2.3.6"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.12.10",
+    "@babel/node": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
+    "babel-eslint": "^10.1.0",
+    "eslint-config-airbnb": "^18.2.1",
+    "nodemon": "^2.0.7"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "start": "nodemon --exec babel-node src",
+    "nodemon": "nodemon ./src/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rishabh-successive/apollo-server.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/rishabh-successive/apollo-server/issues"
+  },
+  "homepage": "https://github.com/rishabh-successive/apollo-server#readme"
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "apollo-server-express": "^2.19.1",
     "dotenv": "^8.2.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.22.1",
     "esm": "^3.2.25",
     "express": "^4.17.1",
     "graphql": "^15.4.0",
@@ -17,6 +19,7 @@
     "@babel/node": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "babel-eslint": "^10.1.0",
+    "eslint": "^7.17.0",
     "eslint-config-airbnb": "^18.2.1",
     "nodemon": "^2.0.7"
   },

--- a/src/Server.js
+++ b/src/Server.js
@@ -15,7 +15,7 @@ class Server {
   setupRoutes() {
     const { app } = this;
     app.get('/', (req, res) => {
-      res.send('Route is running');
+      res.send('Route is running , Add "/graphql" to url to redirect to PLAYGROUND');
     });
   }
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -1,41 +1,51 @@
-// import * as express from 'express';
-var express = require('express')
+import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 
 class Server {
-    app
-    constructor(config) {
-        this.app = express();
+  constructor(config) {
+    this.config = config;
+    this.app = Express();
+  }
+
+  bootstrap() {
+    this.setupRoutes();
+    return this;
+  }
+
+  setupRoutes() {
+    const { app } = this;
+    app.get('/', (req, res) => {
+      res.send('Route is running');
+    });
+  }
+
+  async setApollo(schema) {
+    try {
+      const { app } = this;
+      this.Server = new ApolloServer({
+        ...schema,
+        onHealthCheck: () => new Promise((resolve) => {
+          resolve('I am OK');
+        }),
+      });
+      this.Server.applyMiddleware({ app });
+      this.run();
+    } catch (err) {
+      console.log(err);
     }
+  }
 
-    bootstrap() {
-        this.setupApollo();
-        return this;
-    }
-
-    async setupApollo(schema) {
-        const { app } = this;
-
-        this.Server = new ApolloServer({
-            ...schema,
-            onHealhCheck: () => new Promise((resolve) => {
-                resolve('Route is running');
-            }),
-        });
-        this.Server.applyMiddleware({ app });
-        this.run();
-    }
-
-    run() {
-        const { app, config: { port } } = this;
-        app.listen(port, (err) => {
-            if(err) {
-                console.log(err);
-            }
-            console.log(`App is running on PORT ${ port }`);
-        });
-    }
-
+  run() {
+    const { app, config: { PORT } } = this;
+    console.log(PORT);
+    app.listen(PORT, (err) => {
+      if (err) {
+        console.log(err);
+      } else {
+        console.log(`App is runing on port ${PORT}`);
+      }
+      return this;
+    });
+  }
 }
-
 export default Server;

--- a/src/Server.js
+++ b/src/Server.js
@@ -1,51 +1,56 @@
-import Express from 'express';
+
+// import * as express from 'express';
+var express = require('express')
 import { ApolloServer } from 'apollo-server-express';
 
 class Server {
-  constructor(config) {
-    this.config = config;
-    this.app = Express();
-  }
-
-  bootstrap() {
-    this.setupRoutes();
-    return this;
-  }
-
-  setupRoutes() {
-    const { app } = this;
-    app.get('/', (req, res) => {
-      res.send('Route is running');
-    });
-  }
-
-  async setApollo(schema) {
-    try {
-      const { app } = this;
-      this.Server = new ApolloServer({
-        ...schema,
-        onHealthCheck: () => new Promise((resolve) => {
-          resolve('I am OK');
-        }),
-      });
-      this.Server.applyMiddleware({ app });
-      this.run();
-    } catch (err) {
-      console.log(err);
+    constructor(config) {
+        this.config = config;
+        this.app = express();
     }
-  }
 
-  run() {
-    const { app, config: { PORT } } = this;
-    console.log(PORT);
-    app.listen(PORT, (err) => {
-      if (err) {
-        console.log(err);
-      } else {
-        console.log(`App is runing on port ${PORT}`);
+    bootstrap() {
+        this.setupRoutes();
+        return this;
+    }
+
+    setupRoutes() {
+        const { app } = this;
+        app.get('/', (req, res) => {
+          res.send('Route is running');
+        });
       }
-      return this;
-    });
-  }
+
+    async setupApollo(schema) {
+        try {
+        const { app } = this;
+
+        this.Server = new ApolloServer({
+            ...schema,
+            onHealhCheck: () => new Promise((resolve) => {
+                resolve('Route is running');
+            }),
+        });
+        this.Server.applyMiddleware({ app });
+        this.run();   
+    } catch (err) {
+        console.log(err);
+      }
+    }
+
+    run() {
+        const { app, config: { port } } = this;
+       // console.log(port)
+        app.listen(port, (err) => {
+            if(err) {
+                console.log(err);
+            }
+            else {
+            console.log(`App is running on PORT ${ port }`);
+            }
+            return this;
+        });
+    }
 }
+
 export default Server;

--- a/src/Server.js
+++ b/src/Server.js
@@ -1,6 +1,7 @@
 
 // import * as express from 'express';
 var express = require('express')
+import { createServer } from 'http';
 import { ApolloServer } from 'apollo-server-express';
 
 class Server {
@@ -32,6 +33,8 @@ class Server {
             }),
         });
         this.Server.applyMiddleware({ app });
+        this.httpServer = createServer(app);
+        this.Server.installSubscriptionHandlers(this.httpServer);
         this.run();   
     } catch (err) {
         console.log(err);
@@ -41,7 +44,7 @@ class Server {
     run() {
         const { app, config: { port } } = this;
        // console.log(port)
-        app.listen(port, (err) => {
+       this.httpServer.listen(port, (err) => {
             if(err) {
                 console.log(err);
             }

--- a/src/Server.js
+++ b/src/Server.js
@@ -1,0 +1,41 @@
+// import * as express from 'express';
+var express = require('express')
+import { ApolloServer } from 'apollo-server-express';
+
+class Server {
+    app
+    constructor(config) {
+        this.app = express();
+    }
+
+    bootstrap() {
+        this.setupApollo();
+        return this;
+    }
+
+    async setupApollo(schema) {
+        const { app } = this;
+
+        this.Server = new ApolloServer({
+            ...schema,
+            onHealhCheck: () => new Promise((resolve) => {
+                resolve('Route is running');
+            }),
+        });
+        this.Server.applyMiddleware({ app });
+        this.run();
+    }
+
+    run() {
+        const { app, config: { port } } = this;
+        app.listen(port, (err) => {
+            if(err) {
+                console.log(err);
+            }
+            console.log(`App is running on PORT ${ port }`);
+        });
+    }
+
+}
+
+export default Server;

--- a/src/Server.js
+++ b/src/Server.js
@@ -15,7 +15,7 @@ class Server {
   setupRoutes() {
     const { app } = this;
     app.get('/', (req, res) => {
-      res.send('Route is running , Add "/graphql" to url to redirect to PLAYGROUND');
+      res.send('Route is running');
     });
   }
 

--- a/src/config/configurations.js
+++ b/src/config/configurations.js
@@ -1,12 +1,7 @@
-const envVars = require ('dotenv').config();
+import * as dotenv from 'dotenv';
 
+const envVar = dotenv.config().parsed;
 const config = {
-    port : envVars.parsed.PORT,
-    nodeEnv: envVars.parsed.NODE_ENV
+  PORT: envVar.PORT,
 };
-
-Object.freeze(
-    config
-);
-
-export default config ;
+export default config;

--- a/src/config/configurations.js
+++ b/src/config/configurations.js
@@ -1,0 +1,12 @@
+const envVars = require ('dotenv').config();
+
+const config = {
+    port : envVars.parsed.PORT,
+    nodeEnv: envVars.parsed.NODE_ENV
+};
+
+Object.freeze(
+    config
+);
+
+export default config ;

--- a/src/config/configurations.js
+++ b/src/config/configurations.js
@@ -1,7 +1,14 @@
-import * as dotenv from 'dotenv';
 
-const envVar = dotenv.config().parsed;
+import * as dotenv from 'dotenv';
+const envVars = dotenv.config();
+
 const config = {
-  PORT: envVar.PORT,
+    port: envVars.parsed.PORT,
+    nodeEnv: envVars.parsed.NODE_ENV
 };
+
+Object.freeze(
+    config
+);
+
 export default config;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,1 @@
+export { default as config } from './configurations';

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import Server  from './Server.js';
+import Server from './Server';
 import config from './config/configurations';
 import schema from './modules';
 
-const server = new Server( config );
+const server = new Server(config);
 
 (() => {
-    server.bootstrap().setupApollo(schema);
+  server.bootstrap().setApollo(schema);
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
-import Server from './Server';
-import config from './config/configurations';
+import Server  from './Server.js';
+import config from './config/configurations.js';
 import schema from './modules';
 
-const server = new Server(config);
+const server = new Server( config );
 
-(() => {
-  server.bootstrap().setApollo(schema);
-})();
+server.bootstrap().setupApollo(schema);

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,9 @@
+import Server  from './Server.js';
+import config from './config/configurations';
+import schema from './modules';
+
+const server = new Server( config );
+
+(() => {
+    server.bootstrap().setupApollo(schema);
+})();

--- a/src/lib/constant.js
+++ b/src/lib/constant.js
@@ -1,0 +1,7 @@
+export default {
+    subscriptions: {
+      TRAINEE_ADDED: 'TRAINEE_ADDED',
+      TRAINEE_UPDATED: 'TRAINEE_UPDATED',
+      TRAINEE_DELETED: 'TRAINEE_DELETED',
+    },
+  }; 

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,0 +1,19 @@
+
+import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
+
+import path from 'path';
+
+import * as user from './user';
+
+const typesArray = fileLoader(path.join(__dirname, './**/*.graphql'));
+
+const typeDefs = mergeTypes(typesArray, { all: true });
+
+export default {
+    resolvers: {
+        Query: {
+            ...user.Query,
+        },
+    },
+    typeDefs,
+};

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -9,7 +9,7 @@ const typeDefs = mergeTypes(types, { all: true });
 export default {
   resolvers: {
     Query: {
-      ...user.getProfile,
+      ...user.getMyProfile,
     },
   },
   typeDefs,

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,15 +1,20 @@
 import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
 import path from 'path';
 import * as user from './user';
+import * as trainee from './trainee';
 
 const dir = path.resolve();
-const types = fileLoader(path.join(dir, './**/*.graphql'));
+const types = fileLoader(path.join(__dirname, './**/*.graphql'));
 const typeDefs = mergeTypes(types, { all: true });
 
 export default {
   resolvers: {
     Query: {
       ...user.getMyProfile,
+      ...trainee.query,
+    },
+    Mutation: {
+      ...trainee.mutation,
     },
   },
   typeDefs,

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,21 +1,23 @@
 import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
+
 import path from 'path';
+
 import * as user from './user';
 import * as trainee from './trainee';
 
-const dir = path.resolve();
-const types = fileLoader(path.join(__dirname, './**/*.graphql'));
-const typeDefs = mergeTypes(types, { all: true });
+const typesArray = fileLoader(path.join(__dirname, './**/*.graphql'));
+
+const typeDefs = mergeTypes(typesArray, { all: true });
 
 export default {
-  resolvers: {
-    Query: {
-      ...user.getMyProfile,
-      ...trainee.query,
+    resolvers: {
+        Query: {
+            ...user.getMyProfile,
+            ...trainee.query,
+        },
+        Mutation: {
+            ...trainee.mutation,
+        },
     },
-    Mutation: {
-      ...trainee.mutation,
-    },
-  },
-  typeDefs,
+    typeDefs,
 };

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -18,6 +18,9 @@ export default {
         Mutation: {
             ...trainee.mutation,
         },
+        Subscription: {
+            ...trainee.subscriptions,
+        },
     },
     typeDefs,
 };

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,19 +1,16 @@
-
 import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
-
 import path from 'path';
-
 import * as user from './user';
 
-const typesArray = fileLoader(path.join(__dirname, './**/*.graphql'));
-
-const typeDefs = mergeTypes(typesArray, { all: true });
+const dir = path.resolve();
+const types = fileLoader(path.join(dir, './**/*.graphql'));
+const typeDefs = mergeTypes(types, { all: true });
 
 export default {
-    resolvers: {
-        Query: {
-            ...user.Query,
-        },
+  resolvers: {
+    Query: {
+      ...user.getProfile,
     },
-    typeDefs,
+  },
+  typeDefs,
 };

--- a/src/modules/pubsub.js
+++ b/src/modules/pubsub.js
@@ -1,0 +1,4 @@
+import { PubSub } from 'apollo-server-express';
+
+const instancePubSub = new PubSub();
+export default instancePubSub;

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+    getMyProfile: User!
+}

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -8,3 +8,10 @@ type Mutation {
     updateTrainee(id: ID!, role: String): User!
     deleteTrainee(id: ID!): User!
 }
+
+
+type Subscription {
+    traineeAdded: User!
+    traineeUpdated: User!
+    traineeDeleted: ID!
+}

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -1,11 +1,10 @@
 type Query {
-    getMyProfile: User!
-    getAllTrainees: [User]
-    getTrainee(id:ID):User!
+     getMyProfile: User!
+     getAll: [User]
 }
 
-type Mutation{
+type Mutation {
     createTrainee(user: CreateUserInput): User!
-    updateTrainee(id:ID!, role: String):User!
-    deleteTrainee(id:ID!):ID!
+    updateTrainee(id: ID!, role: String): User!
+    deleteTrainee(id: ID!): User!
 }

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -1,3 +1,11 @@
 type Query {
     getMyProfile: User!
+    getAllTrainees: [User]
+    getTrainee(id:ID):User!
+}
+
+type Mutation{
+    createTrainee(user: CreateUserInput): User!
+    updateTrainee(id:ID!, role: String):User!
+    deleteTrainee(id:ID!):ID!
 }

--- a/src/modules/trainee/index.js
+++ b/src/modules/trainee/index.js
@@ -1,0 +1,2 @@
+export { default as mutation } from './mutation';
+export { default as query } from './query';

--- a/src/modules/trainee/index.js
+++ b/src/modules/trainee/index.js
@@ -1,2 +1,3 @@
 export { default as mutation } from './mutation';
-export { default as query } from './query';
+export { default as query } from './query'; 
+export { default as subscriptions } from './subscription'; 

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -1,0 +1,18 @@
+import userInstance from '../../service/user'
+
+export default {
+    createTrainee: (parent,args,context)=>{
+        const {user} = args;
+        return userInstance.createUser(user);
+    },
+
+    updateTrainee:(parent , args ,context ) =>{
+        const{ id , role } = args;
+        return userInstance.updateUser(id,role);
+
+    },
+    deleteTrainee:(parent,args,context) => {
+        const { id } = args;
+        return userInstance.deleteUser(id,role)
+    }
+ }

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -1,21 +1,27 @@
 import userInstance from '../../service/user';
+import instancePubSub from '../pubsub';
+import constant from '../../lib/constant';
 
 export default {
     createTrainee: (parent,args,context)=>{
         const {user} = args;
-        return userInstance.createUser(user);
+        const newTrainee = userInstance.createUser(user);
+        instancePubSub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: newTrainee });
+        return newTrainee;
     },
 
-    updateTrainee:(parent , args ,context ) =>{
+    updateTrainee: (parent , args ,context ) => {
         const{ id , email, role } = args;
-        return userInstance.updateUser(id, email, role);
+        const updateTraine = userInstance.updateUser(user);
+        instancePubSub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updateTraine });
+         return updateTraine;
 
     },
     
     deleteTrainee:(parent,args,context) => {
         const { id } = args;
-        const del = userInstance.delete(id);
-        console.log(del, 'return');
-        return del;
-    }
+        const deleteTraine = userInstance.delete(id);
+        instancePubSub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: deleteTraine.id });
+        return deleteTraine;
+    },
  }

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -1,4 +1,4 @@
-import userInstance from '../../service/user'
+import userInstance from '../../service/user';
 
 export default {
     createTrainee: (parent,args,context)=>{
@@ -7,12 +7,15 @@ export default {
     },
 
     updateTrainee:(parent , args ,context ) =>{
-        const{ id , role } = args;
-        return userInstance.updateUser(id,role);
+        const{ id , email, role } = args;
+        return userInstance.updateUser(id, email, role);
 
     },
+    
     deleteTrainee:(parent,args,context) => {
         const { id } = args;
-        return userInstance.deleteUser(id,role)
+        const del = userInstance.delete(id);
+        console.log(del, 'return');
+        return del;
     }
  }

--- a/src/modules/trainee/query.js
+++ b/src/modules/trainee/query.js
@@ -1,0 +1,12 @@
+import user from '../../service/user';
+
+export default{
+    getAllTrainee:() => {
+        return user.getAllUsers();
+
+    },
+    getTrainee: (parent,args)=> {
+        const { id } = args;
+        return user.getUser(id);
+    }
+}

--- a/src/modules/trainee/query.js
+++ b/src/modules/trainee/query.js
@@ -1,12 +1,5 @@
 import user from '../../service/user';
 
 export default{
-    getAllTrainee:() => {
-        return user.getAllUsers();
-
-    },
-    getTrainee: (parent,args)=> {
-        const { id } = args;
-        return user.getUser(id);
-    }
+    getAll: () => user.getAll(),
 }

--- a/src/modules/trainee/subscription.js
+++ b/src/modules/trainee/subscription.js
@@ -1,0 +1,14 @@
+import instancePubSub from '../pubsub';
+import constant from '../../lib/constant';
+
+export default {
+    traineeAdded: {
+        subscribe: () => instancePubSub.asyncIterator([constant.subscriptions.TRAINEE_ADDED]),
+    },
+    traineeUpdated: {
+        subscribe: () => instancePubSub.asyncIterator([constant.subscriptions.TRAINEE_UPDATED]),
+    },
+    traineeDeleted: {
+        subscribe: () => instancePubSub.asyncIterator([constant.subscriptions.TRAINEE_DELETED]),
+    },
+}; 

--- a/src/modules/trainee/types.graphql
+++ b/src/modules/trainee/types.graphql
@@ -1,6 +1,4 @@
-
-type User {
-    id: ID!
+input CreateUserInput {
     name: String!
     email: String!
     role: String!

--- a/src/modules/user/index.js
+++ b/src/modules/user/index.js
@@ -1,0 +1,1 @@
+export { default as Query } from './query';

--- a/src/modules/user/index.js
+++ b/src/modules/user/index.js
@@ -1,1 +1,1 @@
-export { default as Query } from './query';
+export { default as getMyProfile } from './query';

--- a/src/modules/user/query.js
+++ b/src/modules/user/query.js
@@ -1,0 +1,9 @@
+export default {
+    getMyProfile: () => {
+        return {
+            id: 1,
+            name: "Rishabh",
+            email: "rishabh@successive.tech"
+        }
+    },
+}

--- a/src/modules/user/query.js
+++ b/src/modules/user/query.js
@@ -1,9 +1,7 @@
 export default {
-    getMyProfile: () => {
-        return {
-            id: 1,
-            name: "Rishabh",
-            email: "rishabh@successive.tech"
-        }
-    },
-}
+    getMyProfile: () => ({
+      id: 1,
+      name: 'rishabh',
+      email: 'rishabh.y@successive.tech',
+    }),
+  };

--- a/src/modules/user/query.js
+++ b/src/modules/user/query.js
@@ -1,7 +1,5 @@
+import user from '../../service/user';
+
 export default {
-    getMyProfile: () => ({
-      id: 1,
-      name: 'rishabh',
-      email: 'rishi@successive.tech',
-    }),
+    getProfile: () => user.getAll(),
   };

--- a/src/modules/user/query.js
+++ b/src/modules/user/query.js
@@ -2,6 +2,6 @@ export default {
     getMyProfile: () => ({
       id: 1,
       name: 'rishabh',
-      email: 'rishabh.y@successive.tech',
+      email: 'rishi@successive.tech',
     }),
   };

--- a/src/modules/user/query.js
+++ b/src/modules/user/query.js
@@ -1,5 +1,5 @@
 import user from '../../service/user';
 
 export default {
-    getProfile: () => user.getAll(),
-  };
+    getMyProfile: () => user.getAll(),
+};

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -1,6 +1,6 @@
 
 type User {
     id: ID!
-    name: string!
-    email: string!
+    name: String!
+    email: String!
 }

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -1,0 +1,6 @@
+
+type User {
+    id: ID!
+    name: string!
+    email: string!
+}

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -4,8 +4,9 @@ class User {
         this.users = new Map();
         this.id = 0;
     }
-    getAllUsers(){
-        return this.users;
+    getAll(){
+        const details = this.users.values();
+        return details;
 
     }
     
@@ -15,19 +16,16 @@ class User {
         return this.users.get(this.id);
     }
 
-    updateUser(id,role){
+    updateUser(id,email){
         const user = this.user.get(Number(id));
-        this.users.set(Number(id),{...user,role });
+        this.users.set(Number(id),{...user,email });
         return this.users.get(Number(id));
     }
 
     deleteUser(id) {
+        const deleteRecords = this.users.get(Number(id));
         this.users.delete(Number(id));
-        return id;
-    }
-
-    getUser(id){
-        return this.users.get(Number(id));
+        return deleteRecords;
     }
 }
 

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -1,0 +1,34 @@
+class User {
+    constructor() {
+
+        this.users = new Map();
+        this.id = 0;
+    }
+    getAllUsers(){
+        return this.users;
+
+    }
+    
+    createUser(user){
+        this.id += 1;
+        this.users.set(this.id,{ ...user , id : this.id });
+        return this.users.get(this.id);
+    }
+
+    updateUser(id,role){
+        const user = this.user.get(Number(id));
+        this.users.set(Number(id),{...user,role });
+        return this.users.get(Number(id));
+    }
+
+    deleteUser(id) {
+        this.users.delete(Number(id));
+        return id;
+    }
+
+    getUser(id){
+        return this.users.get(Number(id));
+    }
+}
+
+export default new User();


### PR DESCRIPTION
AC

Add subscriptions for add, edit and delete trainee.

Prerequisites

    Add apollo-server package
    Add subscription middleware to the apollo server.

Steps

    Add a file called pubsub.js inside the module folder where you have to import the Pubsub class from the apollo server and export its instance.
    Add the subscription type with addTrainee, updateTrainee, and deleteTrainee with return types as User for the first two and ID for the last one.
    Add a file named subscription.js inside the trainee module.
        Import Pubsub instance from pubsub.js
        Define all the pubsub methods on the basis of topic.
    From your mutations publish your data, for example, publish data for created Trainee on createTrainee topic.
    The last step would be updating the server.js file so that it starts accepting WebSocket requests.
        Import createServer from the HTTP module.
        Call the create server with the express app as an argument.
        Pass the newly created server instance as an argument to the installSubscriptionsHandlers method of the apollo server instance.
        Update the run method so that it starts the server using the newly created server instance.
